### PR TITLE
improved code for buffer and improved test coverage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 
@@ -37,8 +36,9 @@ type Config struct {
 }
 
 type Buffer struct {
-	LoopTimeout int
-	Size        int
+	LoopTimeout       int
+	Size              int
+	MaxEventsToBuffer int
 }
 
 type Mappers struct {
@@ -79,8 +79,6 @@ func readConfig() (*Config, error) {
 	if _, err := toml.Decode(string(file), &cnf); err != nil {
 		return nil, err
 	}
-
-	fmt.Println(cnf.DataBase, configFile)
 
 	// эти параметры лучше ложить например в Vault, но не хочется усложнять, поэтому сделал так
 	cnf.DataBase.DBName = os.Getenv("CLICKHOUSE_NAME")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,10 @@ func TestReadConfig(t *testing.T) {
 	require.Equal(t, 120, cnf.Service.WriteTimeout)
 	require.Equal(t, 8080, cnf.Service.Port)
 
+	require.Equal(t, 10, cnf.Buffer.LoopTimeout)
+	require.Equal(t, 5, cnf.Buffer.MaxEventsToBuffer)
+	require.Equal(t, 60000, cnf.Buffer.Size)
+
 	events := map[string]uint8{"app_start": 1, "onClose": 6, "onCreate": 4, "onDestroy": 5, "onPause": 2, "onRotate": 3, "panic": 7}
 	require.Equal(t, fmt.Sprintf("%v", events), fmt.Sprintf("%v", cnf.Mappers.Events))
 

--- a/internal/utils/extractors_test.go
+++ b/internal/utils/extractors_test.go
@@ -18,7 +18,7 @@ func TestSplitOsAndVersion(t *testing.T) {
 		{
 			name:          "payload from request example",
 			payload:       "IOS 13.5.1",
-			os:            "IOS",
+			os:            "ios",
 			version:       "13.5.1",
 			expectedError: nil,
 		}, {
@@ -39,6 +39,12 @@ func TestSplitOsAndVersion(t *testing.T) {
 			os:            "",
 			version:       "",
 			expectedError: errors.New(`can't extract data from string: ""`),
+		}, {
+			name:          "lowercase os type with valid version",
+			payload:       "ios 13.0.1",
+			os:            "ios",
+			version:       "13.0.1",
+			expectedError: nil,
 		},
 	}
 

--- a/pkg/eventservice/service/model_test.go
+++ b/pkg/eventservice/service/model_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"event/internal/config"
+	"event/pkg/eventservice/service/data"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataModelCast(t *testing.T) {
+
+	initMappers(config.Mappers{
+		Events:    map[string]uint8{"app_start": 1, "onClose": 6, "onCreate": 4, "onDestroy": 5, "onPause": 2, "onRotate": 3, "panic": 7},
+		DeviceOs:  map[string]uint8{"android": 3, "ios": 2, "linux": 5, "macos": 7, "unix": 6, "unsupported": 1, "windows": 4},
+		OsVersion: map[string]uint16{"10.0.1": 0x5209, "13.5.1": 0x2c57, "13.5.2": 0x2c58, "13.5.3": 0x2c59, "4.4.4": 0x98c, "5.0.1": 0x9c5},
+	})
+
+	tests := []struct {
+		name          string
+		payload       ServiceEventModel
+		ExpectedModel *data.DataEventModel
+		isValid       bool
+	}{
+		{
+			name: "example from task",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:    "ybuRi8mAUypxjbxQ",
+				ParamStr:   "some text",
+				Ip:         "8.8.8.8",
+				DeviceOs:   "IOS 13.5.1",
+				Event:      "app_start",
+				Sequence:   1,
+				ParamInt:   0,
+			},
+			ExpectedModel: &data.DataEventModel{
+				ClientTime:      time.Date(2020, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ServerTime:      time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				DeviceId:        "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:         "ybuRi8mAUypxjbxQ",
+				ParamStr:        "some text",
+				Ip:              0x8080808,
+				Sequence:        1,
+				ParamInt:        0,
+				DeviceOs:        osType["ios"],
+				DeviceOsVersion: osVersion["13.5.1"],
+				Event:           eventType["app_start"],
+			},
+			isValid: true,
+		}, {
+			name: "invalid client time format",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00:00",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		}, {
+			name: "invalid uuid",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9ENOT_HEHE",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		}, {
+			name: "invalid session length",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:    "ybuRi8mAUypxjbxQ+useless_payload",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		}, {
+			name: "invalid param_str length",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:    "ybuRi8mAUypxjbxQ",
+				ParamStr:   "some text",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		}, {
+			name: "unsupported os version template",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:    "ybuRi8mAUypxjbxQ",
+				ParamStr:   "some text",
+				Ip:         "8.8.8.8",
+				DeviceOs:   "IOS 13.5.1.0",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		}, {
+			name: "not supported event",
+			payload: ServiceEventModel{
+				ServerTime: time.Date(2023, time.December, 1, 23, 59, 0, 0, time.UTC),
+				ClientTime: "2020-12-01 23:59:00",
+				DeviceId:   "0287D9AA-4ADF-4B37-A60F-3E9E645C821E",
+				Session:    "ybuRi8mAUypxjbxQ",
+				ParamStr:   "some text",
+				Ip:         "8.8.8.8",
+				DeviceOs:   "IOS 13.5.1",
+				Event:      "bad_app_start",
+			},
+			ExpectedModel: nil,
+			isValid:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, ok := tt.payload.toDataModel()
+			require.Equal(t, tt.isValid, ok)
+
+			if tt.isValid {
+				require.Equal(t, tt.ExpectedModel.ClientTime, obj.ClientTime)
+				require.Equal(t, tt.ExpectedModel.ServerTime, obj.ServerTime)
+				require.Equal(t, tt.ExpectedModel.DeviceId, obj.DeviceId)
+				require.Equal(t, tt.ExpectedModel.Session, obj.Session)
+				require.Equal(t, tt.ExpectedModel.ParamStr, obj.ParamStr)
+				require.Equal(t, tt.ExpectedModel.Ip, obj.Ip)
+				require.Equal(t, tt.ExpectedModel.Sequence, obj.Sequence)
+				require.Equal(t, tt.ExpectedModel.ParamInt, obj.ParamInt)
+				require.Equal(t, tt.ExpectedModel.DeviceOs, obj.DeviceOs)
+				require.Equal(t, tt.ExpectedModel.DeviceOsVersion, obj.DeviceOsVersion)
+				require.Equal(t, tt.ExpectedModel.Event, obj.Event)
+			} else {
+				require.Nil(t, obj)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
➜  service git:(refactor_buffer) $ pwd
.../event/pkg/eventservice/service
➜  service git:(refactor_buffer) $ go test . -cover                                                   
ok      event/pkg/eventservice/service  (cached)        coverage: 57.4% of statements
```